### PR TITLE
Fix missing go sum. Mod tidy

### DIFF
--- a/go.sum
+++ b/go.sum
@@ -472,8 +472,9 @@ github.com/cosmos/keyring v1.1.7-0.20210622111912-ef00f8ac3d76 h1:DdzS1m6o/pCqeZ
 github.com/cosmos/keyring v1.1.7-0.20210622111912-ef00f8ac3d76/go.mod h1:0mkLWIoZuQ7uBoospo5Q9zIpqq6rYCPJDSUdeCJvPM8=
 github.com/cosmos/ledger-cosmos-go v0.11.1 h1:9JIYsGnXP613pb2vPjFeMMjBI5lEDsEaF6oYorTy6J4=
 github.com/cosmos/ledger-cosmos-go v0.11.1/go.mod h1:J8//BsAGTo3OC/vDLjMRFLW6q0WAaXvHnVc7ZmE8iUY=
-github.com/cosmos/ledger-go v0.9.2 h1:Nnao/dLwaVTk1Q5U9THldpUMMXU94BOTWPddSmVB6pI=
 github.com/cosmos/ledger-go v0.9.2/go.mod h1:oZJ2hHAZROdlHiwTg4t7kP+GKIIkBT+o6c9QWFanOyI=
+github.com/cosmos/ledger-go v0.9.3 h1:WGyZK4ikuLIkbxJm3lEr1tdQYDdTdveTwoVla7hqfhQ=
+github.com/cosmos/ledger-go v0.9.3/go.mod h1:oZJ2hHAZROdlHiwTg4t7kP+GKIIkBT+o6c9QWFanOyI=
 github.com/cpuguy83/go-md2man v1.0.10/go.mod h1:SmD6nW6nTyfqj6ABTjUi3V3JVMnlJmwcJI5acqYI6dE=
 github.com/cpuguy83/go-md2man/v2 v2.0.0-20190314233015-f79a8a8ca69d/go.mod h1:maD7wRr/U5Z6m/iR4s+kqSMx2CaBsrgA7czyZG/E6dU=
 github.com/cpuguy83/go-md2man/v2 v2.0.0/go.mod h1:maD7wRr/U5Z6m/iR4s+kqSMx2CaBsrgA7czyZG/E6dU=


### PR DESCRIPTION
This fixes the following issue when building with go18.1

```
../go/pkg/mod/github.com/cosmos/ledger-cosmos-go@v0.11.1/user_app.go:23:2: missing go.sum entry for module providing package github.com/cosmos/ledger-go (imported by github.com/cosmos/ledger-cosmos-go); to add:
	go get github.com/cosmos/ledger-cosmos-go@v0.11.1
make: *** [Makefile:126: install] Error 1
```

I've just run go mod tidy. 

After doing it, then:

```
tedcrypto@rebuschain  rebus.core git:(fix-missing-go-sum) make install
go install -tags "netgo ledger" -ldflags '-X github.com/cosmos/cosmos-sdk/version.Name=rebus -X github.com/cosmos/cosmos-sdk/version.AppName=rebusd -X github.com/cosmos/cosmos-sdk/version.Version=fix-missing-go-sum.c48b765a842dc4db0491e945b361689d2b3a4c08 -X github.com/cosmos/cosmos-sdk/version.Commit=c48b765a842dc4db0491e945b361689d2b3a4c08 -X "github.com/cosmos/cosmos-sdk/version.BuildTags=netgo ledger," -X github.com/tendermint/tendermint/version.TMCoreSemVer=v0.34.20-0.20220517115723-e6f071164839 -w -s' -trimpath  ./...

tedcrypto@rebuschain  rebus.core git:(fix-missing-go-sum) rebusd version
fix-missing-go-sum.c48b765a842dc4db0491e945b361689d2b3a4c08
```